### PR TITLE
Replace simple

### DIFF
--- a/matlabFiles/rga.m
+++ b/matlabFiles/rga.m
@@ -90,10 +90,10 @@ end
 A=subs(A,complex(0,w));
 
 if isa(A,'sym')==true
-    A=simple(subs(A,complex(0,w)));
+    A=simplify(subs(A,complex(0,w)));
 end
 
 if no==2
-    cond=simple(sum(sum(abs(A))));
+    cond=simplify(sum(sum(abs(A))));
 end
 %------------- END OF CODE --------------

--- a/matlabFiles/smform.m
+++ b/matlabFiles/smform.m
@@ -78,7 +78,7 @@ end
 %g=factor(g);
 P=d*g;
 S=maple('smith',P,p);
-M=simple(S/d);
+M=simplify(S/d);
 
 %****************************************************************
 % Determines the poles and zeros

--- a/matlabFiles/ss2sym.m
+++ b/matlabFiles/ss2sym.m
@@ -34,5 +34,5 @@ p=sym('p');
 if n~=m
     error('El sistema debe ser cuadrado')
 end
-g=simple(c*inv(p*eye(n) - a)*b +d);
+g=simplify(c*inv(p*eye(n) - a)*b +d);
 %------------- END OF CODE --------------

--- a/matlabFiles/tf2sym.m
+++ b/matlabFiles/tf2sym.m
@@ -51,5 +51,5 @@ for i=1:n
     end
 end
 
-g=simple(g);
+g=simplify(g);
 %------------- END OF CODE --------------


### PR DESCRIPTION
`simple` is deprecated, therefore it was replaced by `simplify` 